### PR TITLE
FIX psnr + dataloaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ bash download.sh afhq-cat-dataset
 bash download.sh pretrained-network-afhq-cat
 ```
 
-Note that as the dataset AFHQ-Cat doesn't have a validation split, we create one when downloading the dataset. 
+Note that as the dataset AFHQ-Cat doesn't have a validation split, we create one when downloading the dataset.
 
 Alternatively, the FM models can directly be downloaded here: [CelebA model](https://drive.google.com/file/d/1ZZ6S-PGRx-tOPkr4Gt3A6RN-PChabnD6/view?usp=drive_link), [AFHQ-Cat model](https://drive.google.com/file/d/1FpD3cYpgtM8-KJ3Qk48fcjtr1Ne_IMOF/view?usp=drive_link), [MNIST-Dirichlet model](https://drive.google.com/file/d/1If5gkWEfChJHc8v8CCEhGhEeeAqsxKTz/view?usp=drive_link)
 
 And the denoisers for the PnP-GS method here: [CelebA model](https://drive.google.com/file/d/1ZqBeafErEogaXFupW0ZSLL7P9QoRA-lN/view?usp=drive_link), [AFHQ-Cat model](https://drive.google.com/file/d/17AXI9p17c7h_xaI19qDcTT2u9_wu0DQY/view?usp=drive_link)
+
+Disclaimer: The provided CelebA checkpoints correspond to a retrained model and are not the exact ones used in the paper, but results should only vary very slightly.
 
 ## 2. Training
 
@@ -90,7 +92,7 @@ The available methods are
 ### 3.1. Finding the optimal parameters on the validation set
 
 The optimal parameters can tuned running
-```python 
+```python
 python bash scripts/script_val.sh
 ```
 

--- a/pnpflow/dataloaders.py
+++ b/pnpflow/dataloaders.py
@@ -84,9 +84,9 @@ class DataLoaders:
             ])
 
             # transform = False
-            img_dir_test = './data/afhq_cat/test/cat/'
-            img_dir_val = './data/afhq_cat/val/cat/'
-            img_dir_train = './data/afhq_cat/train/cat/'
+            img_dir_test = '.data/afhq_cat/test/cat/'
+            img_dir_val = '.data/afhq_cat/val/cat/'
+            img_dir_train = '.data/afhq_cat/train/cat/'
             test_dataset = AFHQDataset(
                 img_dir_test, batchsize=self.batch_size_test, transform=transform)
             val_dataset = AFHQDataset(
@@ -154,7 +154,7 @@ class CelebAHQDataset(Dataset):
     """CelebA HQ dataset."""
 
     def __init__(self, data_dir, batchsize, transform=None):
-        self.files = os.listdir(data_dir)
+        self.files = sorted(os.listdir(data_dir))
         self.root_dir = data_dir
         self.num_imgs = len(os.listdir(self.root_dir))
         self.transform = transform
@@ -185,7 +185,7 @@ class AFHQDataset(Dataset):
     """AFHQ Cat dataset."""
 
     def __init__(self, img_dir, batchsize, category='cat', transform=None):
-        self.files = os.listdir(img_dir)
+        self.files = sorted(os.listdir(img_dir))
         self.num_imgs = len(self.files)
         self.batchsize = batchsize
         self.img_dir = img_dir

--- a/pnpflow/methods/ot_ode.py
+++ b/pnpflow/methods/ot_ode.py
@@ -149,14 +149,14 @@ class OT_ODE(object):
                     if self.args.save_results:
                         if iteration % 10 == 0 or self.should_save_image(iteration, steps):
                             restored_img = x.detach().clone()
-                    # utils.save_images(
-                    #     clean_img, noisy_img, restored_img, self.args, H_adj, iter=iteration)
-                    utils.compute_psnr(clean_img, noisy_img,
-                                       restored_img, self.args, H_adj, iter=iteration)
-                    utils.compute_ssim(clean_img, noisy_img,
-                                       restored_img, self.args, H_adj, iter=iteration)
-                    utils.compute_lpips(clean_img, noisy_img,
-                                        restored_img, self.args, H_adj, iter=iteration)
+                            # utils.save_images(
+                            #     clean_img, noisy_img, restored_img, self.args, H_adj, iter=iteration)
+                            utils.compute_psnr(clean_img, noisy_img,
+                                               restored_img, self.args, H_adj, iter=iteration)
+                            utils.compute_ssim(clean_img, noisy_img,
+                                               restored_img, self.args, H_adj, iter=iteration)
+                            utils.compute_lpips(clean_img, noisy_img,
+                                                restored_img, self.args, H_adj, iter=iteration)
 
                     if self.args.compute_time:
                         torch.cuda.synchronize()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 autograd==1.6.2
 Cython==3.0.10
-deepinv==0.2.0
+deepinv==0.3.2
 diffeqtorch==1.0.0
 gmpy2
 h5py


### PR DESCRIPTION
- Fix PSNR computation: switch from `skimage.metrics.peak_signal_noise_ratio` to `torchmetrics.functional.image.peak_signal_noise_ratio` so that the PSNR value does not depend on batch size (computation image wise and not full tensor) 
- Fix indentation for save_results on `pnpflow.methods.ot_ode.py`
- Add `sorted` to os.listdir in dataloaders to ensure images used for test set are the same across filesystems.  
- Add disclaimer in README regarding checkpoints (the Celeba OT FM model has been retrained since submission of the paper, so results with provided checkpoint may vary a bit from the reported ones).
- Update deepinv version
